### PR TITLE
bug: endless spinner when api request fails

### DIFF
--- a/lang/en/repository_pixabay.php
+++ b/lang/en/repository_pixabay.php
@@ -36,3 +36,5 @@ $string['popular'] = "Popular";
 $string['latest'] = "Latest";
 $string['safesearch'] = "Safe Search<br>(only images suitable for all ages should be returned)";
 $string['warning'] = "Key isn't set !! You must set it in Pixabay Repository settings.";
+$string['queryfailed'] = "Pixabay search query failed, please try again.";
+$string['queryfailed_help'] = "Query failed due to search string being greater than 100 character limit imposed by Pixabay, or API hourly request threshold being reached.";

--- a/lib.php
+++ b/lib.php
@@ -79,24 +79,30 @@ class repository_pixabay extends repository {
         $url = "https://pixabay.com/api/?key=" . $key . "&q=" . $q . "&order=" . $sort . "&safesearch=" . $safesearch;
         $url .= "&per_page=" . $perpage . "&page=" . $page;
         $json = file_get_contents($url);
-        $results = json_decode($json);
 
-        foreach ($results->hits as $key => $value) {
-            $title = str_replace("https://pixabay.com/", "", $value->pageURL);
-            $title = preg_replace("/-(\d+)\//", ".jpg", $title);
-            $list[] = array(
-            'shorttitle' => $title,
-            'thumbnail_title' => $title,
-            'title' => $title,
-            'description' => $title,
-            'thumbnail' => $value->webformatURL,
-            'thumbnail_width' => 150,
-            'thumbnail_height' => 100,
-            'size' => $value->imageSize,
-            'author' => $value->user,
-            'source' => $value->webformatURL,
-            'license' => 'Creative Commons CC0'
-            );
+        if (empty($json)) {
+            print_error('queryfailed', 'repository_pixabay', '', null,
+                get_string('queryfailed_help', 'repository_pixabay'));
+        } else {
+            $results = json_decode($json);
+
+            foreach ($results->hits as $key => $value) {
+                $title = str_replace("https://pixabay.com/", "", $value->pageURL);
+                $title = preg_replace("/-(\d+)\//", ".jpg", $title);
+                $list[] = array(
+                    'shorttitle' => $title,
+                    'thumbnail_title' => $title,
+                    'title' => $title,
+                    'description' => $title,
+                    'thumbnail' => $value->webformatURL,
+                    'thumbnail_width' => 150,
+                    'thumbnail_height' => 100,
+                    'size' => $value->imageSize,
+                    'author' => $value->user,
+                    'source' => $value->webformatURL,
+                    'license' => 'Creative Commons CC0'
+                );
+            }
         }
 
         $ret  = array();
@@ -105,7 +111,6 @@ class repository_pixabay extends repository {
         if ($ret['page'] < 1) {
             $ret['page'] = 1;
         }
-        $start = 1;
         $max = ceil(($results->totalHits) / $perpage);
         $ret['list'] = $list;
         $ret['norefresh'] = true;

--- a/lib.php
+++ b/lib.php
@@ -79,6 +79,7 @@ class repository_pixabay extends repository {
         $url = "https://pixabay.com/api/?key=" . $key . "&q=" . $q . "&order=" . $sort . "&safesearch=" . $safesearch;
         $url .= "&per_page=" . $perpage . "&page=" . $page;
         $json = file_get_contents($url);
+        $list = [];
 
         if (empty($json)) {
             print_error('queryfailed', 'repository_pixabay', '', null,

--- a/lib.php
+++ b/lib.php
@@ -81,7 +81,7 @@ class repository_pixabay extends repository {
         $json = file_get_contents($url);
         $list = [];
 
-        if (empty($json)) {
+        if (isset($json) && empty($json)) {
             print_error('queryfailed', 'repository_pixabay', '', null,
                 get_string('queryfailed_help', 'repository_pixabay'));
         } else {
@@ -117,7 +117,7 @@ class repository_pixabay extends repository {
         $ret['norefresh'] = true;
         $ret['nosearch'] = false;
         // If the number of results is smaller than $max, it means we reached the last page.
-        $ret['pages'] = (count($ret['list']) < $max) ? $ret['page'] : -1;
+        $ret['pages'] = (empty($list) || count($list) < $max) ? $ret['page'] : -1;
         return $ret;
     }
 


### PR DESCRIPTION
Fixed an issue where, if the API search request to Pixabay failed, file_get_contents would return an empty value, and a null list value would be passed back to repository API, resulting in an endless spinner animation making it look like results were loading, when the query has actually failed.

Replaced endless spinner with error message and additional debugging message for admins.

chore: removed unused `$start` variable as well.