### PR TITLE
bug: pagination not working

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -112,12 +112,16 @@ class repository_pixabay extends repository {
         if ($ret['page'] < 1) {
             $ret['page'] = 1;
         }
-        $max = ceil(($results->totalHits) / $perpage);
         $ret['list'] = $list;
         $ret['norefresh'] = true;
         $ret['nosearch'] = false;
-        // If the number of results is smaller than $max, it means we reached the last page.
-        $ret['pages'] = (empty($list) || count($list) < $max) ? $ret['page'] : -1;
+
+        if (!empty($results->totalHits)) {
+            $ret['pages'] = (int) ceil(($results->totalHits) / $perpage);
+        } else {
+            $ret['pages'] = 1;
+        }
+
         return $ret;
     }
 


### PR DESCRIPTION
The previous changes used a page number of -1 if there were remaining pages to be rendered on the next AJAX call from the repository API.
This is not the correct way to handle pages with the repository API and was causing only the first page to be rendered in some cases.
Fixed pagination by passing full page count to the listing.